### PR TITLE
added node.gyp for node >= 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ You will need:
 
 Building:
 
+If you are using node >= v0.8.0
+
+    node-gyp configure && node-gyp build
+
+If you are using node < v0.8.0
+
     node-waf configure && node-waf build
 
 Copy Generated library to current directory. Depending on the version of node.js you are using, one of the 2 commands below is the correct one.

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,14 @@
+{
+    'targets' : [
+	{
+	    'target_name' : 'curllib.node',
+	    'type' : 'shared_library',
+	    'sources' : [
+		'curllib.cc'
+	    ],
+	    'libraries' : [
+		'-lcurl'
+	    ]
+	}
+    ]
+}


### PR DESCRIPTION
node-waf has been officially deprecated since node v.8.0(http://blog.nodejs.org/2012/06/25/node-v0-8-0/).

i wrote binding.gyp for new build tool node-gyp.
