### PR TITLE
fixed wrong configuration @ binding.gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,8 +1,7 @@
 {
     'targets' : [
 	{
-	    'target_name' : 'curllib.node',
-	    'type' : 'shared_library',
+	    'target_name' : 'curllib',
 	    'sources' : [
 		'curllib.cc'
 	    ],


### PR DESCRIPTION
sorry, there were mistakes in my binding.gyp.
- node module should be built as static library.
- the name of static library file built from node-gyp differs from that of node-waf version.
