### PR TITLE
fixed compiled extension reference

### DIFF
--- a/http-sync.js
+++ b/http-sync.js
@@ -1,4 +1,10 @@
-var _cl = require('./curllib');
+var _cl = null;
+try {
+  _cl = require('./build/Release/curllib.node');
+} catch (error) {
+  _cl = require('./build/default/curllib.node');
+}
+
 var curllib = new _cl.CurlLib();
 
 // console.log("curlllib:", curllib);


### PR DESCRIPTION
The reference to the compiled extension assumes that you manually moved it to the root of the project. In an automated `npm install` use, this doesn't happen.

This PR attempts to load the module from its compiled paths, assuming `node >= 0.8.0` first, but falling back to the old path.

An alternative approach would be to have each script copy the compiled extension to the root after compiling. I don't know enough about the compiled extensions scripts to mess with that, especially with `node < 0.8.0`. If you'd prefer that approach, please do that soon so that this can be used without manual steps. Or, at least accept this PR in the short term and update it later.
