### PR TITLE
add full url option

### DIFF
--- a/http-sync.js
+++ b/http-sync.js
@@ -29,15 +29,19 @@ CurlRequest.prototype = {
     }, 
     end: function(data) {
 	this.write(data);
-	var _ep = this._options.protocol + '://' + this._options.host + 
-	    ':' + this._options.port + this._options.path;
+    function getUrl(options) {
+        if (options.url) return options.url;
+
+        return options.protocol + '://' + options.host +
+            ':' + options.port + options.path;
+    }
 	var _h = [ ];
 	var k;
 	for (k in this._headers) {
 	    _h.push(k + ': ' + this._headers[k]);
 	}
 
-	var ret = curllib.run(this._options.method, _ep, 
+	var ret = curllib.run(this._options.method, getUrl(this._options),
 			      _h, this._options.body);
 
 	if (ret.error) {


### PR DESCRIPTION
I prefer to send a full url to libraries like this in most cases. This PR adds an override option `url` where it will be used if it exists. Otherwise, the current logic takes over.

I suggest addressing my other PRs before this one. I can resolve any conflicts that come up.
