### PR TITLE
force statusCode to be a number

### DIFF
--- a/http-sync.js
+++ b/http-sync.js
@@ -72,7 +72,7 @@ CurlRequest.prototype = {
                 }
             });
             return {
-                statusCode: statusCode,
+                statusCode: parseInt(statusCode, 10),
                 headers: _h
             };
         }


### PR DESCRIPTION
`statusCode` appears to always be a string. This forces it to be a number.
