### PR TITLE
Strip last semicolon from protocol

### DIFF
--- a/http-sync.js
+++ b/http-sync.js
@@ -125,7 +125,7 @@ CurlRequest.prototype = {
 exports.request = function(options) {
     options.method = options.method ? options.method.toUpperCase() : 'GET';
 
-    options.protocol = options.protocol || 'http';
+    options.protocol = (options.protocol || 'http').replace(/:$/, '');
     options.port = options.port || (options.protocol === 'https' ? 443 : 80);
     options.path = options.path || '/';
     options.headers = options.headers || { };


### PR DESCRIPTION
[Node.js idiom is to have a semicolon in a parsed url.protocol field](http://nodejs.org/api/url.html#url_url)
Removing it allows better integration with existing code.
