### PR TITLE
Use nan to abstract away v8 API changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /build
-
+/node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - 0.8
+  - 0.10
+  - iojs

--- a/binding.gyp
+++ b/binding.gyp
@@ -7,7 +7,10 @@
 	    ],
 	    'libraries' : [
 		'-lcurl'
-	    ]
+	    ],
+	    'include_dirs': [
+		"<!(node -e \"require('nan')\")"
+	    ],
 	}
     ]
 }

--- a/http-sync.js
+++ b/http-sync.js
@@ -1,3 +1,5 @@
+var caseless = require('caseless');
+
 var _cl = null;
 try {
   _cl = require('./build/Release/curllib.node');
@@ -10,6 +12,7 @@ var curllib = new _cl.CurlLib();
 function CurlRequest(options) {
     this._options = options;
     this._headers = { };
+    this._caseless = caseless(this._headers);
 
     var k;
     for (k in this._options.headers) {
@@ -19,13 +22,13 @@ function CurlRequest(options) {
 
 CurlRequest.prototype = {
     getHeader: function(name) {
-        return this._headers[name.toLowerCase()];
+        return this._caseless.get(name);
     },
     removeHeader: function(name) {
-        delete this._headers[name.toLowerCase()];
+        delete this._caseless.del(name);
     },
     setHeader: function(name, value) {
-        this._headers[name.toLowerCase()] = value;
+        this._caseless.set(name, value);
     },
     write: function(data) {
         data = data || '';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-sync",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A synchronous HTTP Client library for node.js",
   "main": "http-sync.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A synchronous HTTP Client library for node.js",
   "main": "http-sync.js",
   "scripts": {
-    "install": "node-gyp rebuild"
+    "test": "node test/index.js"
   },
   "repository": {
     "type": "git",
@@ -33,5 +33,9 @@
   ],
   "license": "BSD",
   "gypfile": true,
-  "readmeFilename": "README.md"
+  "readmeFilename": "README.md",
+  "dependencies": {
+    "nan": "~1.6.2",
+    "caseless": "~0.9.0"
+  }
 }

--- a/test.js
+++ b/test.js
@@ -45,7 +45,8 @@ try {
 
 // Test timeout
 var req = http_sync.request({
-    host: 'nodejs1.org',
+    host: '198.51.100.1',
+    port: 91,
     path: '/foobar'
 });
 
@@ -57,12 +58,13 @@ req.setTimeout(10, function() {
 
 res = req.end();
 if (!timedout) {
-    console.log("Timeout is broken");
+    throw new Error('Timeout is broken');
 }
 
 // Test connect timeout
 var req = http_sync.request({
-    host: 'nodejs1.org',
+    host: '198.51.100.1',
+    port: 91,
     path: '/foobar'
 });
 
@@ -78,5 +80,5 @@ req.setConnectTimeout(10, function() {
 
 res = req.end();
 if (!timedout) {
-    console.log("Timeout is broken");
+    throw new Error("Timeout is broken");
 }

--- a/test/echo-server
+++ b/test/echo-server
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+'use strict';
+
+var http = require('http');
+
+var webPort = +process.argv[2];
+
+function respondJSON(req, res) {
+  var body = '';
+  req.setEncoding('utf8');
+  req.on('data', function(chunk) { body += chunk; });
+  req.on('end', function() {
+    res.end(JSON.stringify({
+      headers: req.headers,
+      method: req.method,
+      url: req.url,
+      body: body
+    }));
+  });
+}
+
+http.createServer(respondJSON).listen(webPort);

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,82 @@
+'use strict';
+var spawn = require('child_process').spawn;
+var path = require('path');
+var assert = require('assert');
+
+var request = require('../').request;
+
+var webPort = 4490;
+var echoServerPath = path.join(__dirname, 'echo-server');
+
+function mkReq(path, options) {
+  options = options || {};
+  options.host = '127.0.0.1';
+  options.port = webPort;
+  options.path = path;
+  var res = request(options).end();
+  res.echo = JSON.parse(res.body.toString());
+  return res;
+}
+
+var tests = [
+  function simpleGET() {
+    var res = mkReq('/x');
+    assert.equal(res.echo.method, 'GET');
+    assert.equal(res.echo.url, '/x');
+    assert.equal(res.echo.headers.accept, '*/*');
+  },
+  function simplePOST() {
+    var body = '{"x":42}';
+    var res = mkReq('/', { method: 'POST', body: body });
+    assert.equal(res.echo.method, 'POST');
+    assert.equal(res.echo.body, body);
+  },
+  function sendHeaders() {
+    var headers = {
+      'X-Foo': 'bar'
+    };
+    var res = mkReq('/', { headers: headers });
+    assert.equal(res.echo.headers['x-foo'], headers['X-Foo']);
+  },
+  function postJSON() {
+    var body = '{"x":true}';
+    var headers = {
+      'Content-Type': 'application/json'
+    };
+    var res = mkReq('/', { headers: headers, body: body });
+    assert.equal(res.echo.headers['content-type'], headers['Content-Type']);
+    assert.equal(res.echo.body, body);
+  },
+  function alwaysPass() {}
+];
+
+function runTests() { // ad-hoc reinvention of tape
+  console.log('1..%d', tests.length);
+  // simple GET request
+  var failed = tests.filter(function(t, idx) {
+    try {
+      t();
+      console.log('ok %d - %s', idx + 1, t.name);
+      return false;
+    } catch (err) {
+      console.log('not ok %d - %s', idx + 1, t.name);
+      console.log('  ' + err.stack.split('\n').join('\n  '));
+      return true;
+    }
+  });
+
+  process.exit(failed.length ? 1 : 0);
+}
+
+var echoServer = spawn(echoServerPath, [webPort]);
+process.on('exit', function() {
+  if (echoServer) {
+    try {
+      echoServer.kill();
+    }
+    catch (err) {
+      console.error(err.stack);
+    }
+  }
+});
+setTimeout(runTests, 200);


### PR DESCRIPTION
Replaces direct access to node and v8 APIs by their nan equivalents.
This way the module compiles cleanly against both older versions of
v8 and the ones used in node 0.12 and io.js.

It also changes the `package.json` to specify a `test` script.
This way `npm i && npm t` work for this project which simplifies CI
integration.

See: https://github.com/rvagg/nan