### PR TITLE
Add parameter 'url' so provide full URL.

### DIFF
--- a/http-sync.js
+++ b/http-sync.js
@@ -50,7 +50,7 @@ CurlRequest.prototype = {
     },
     end: function(data) {
         this.write(data);
-        var _ep = this._options.protocol + '://' + this._options.host +
+        var _ep = this._options.url || this._options.protocol + '://' + this._options.host +
             ':' + this._options.port + this._options.path;
         var _h = [ ];
         var k;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-sync",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A synchronous HTTP Client library for node.js",
   "main": "http-sync.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
     {
       "name": "Jan Krems",
       "url": "https://github.com/jkrems"
+    },
+    {
+      "name": "Chad Hatcher",
+      "url": "https://github.com/chatcher"
     }
   ],
   "license": "BSD",


### PR DESCRIPTION
Instead of providing the URL components (protocol, host, port, path), specify the whole url.