### PR TITLE
Support authorization

### DIFF
--- a/http-sync.js
+++ b/http-sync.js
@@ -149,6 +149,10 @@ exports.request = function(options) {
     options.headers = options.headers || { };
     options.host = options.host || '127.0.0.1';
     options.body = options.body || '';
+    if (options.auth && !options.headers['Authorization']) {
+        //basic auth
+        options.headers['Authorization'] = 'Basic ' + new Buffer(options.auth).toString('base64');
+    }
     options.rejectUnauthorized = options.rejectUnauthorized === false ?
 	false : true;
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
     {
       "name": "Jan Krems",
       "url": "https://github.com/jkrems"
+    },
+    {
+      "name": "Boris Serdyuk",
+      "url": "https://github.com/just-boris"
     }
   ],
   "license": "BSD",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-sync",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A synchronous HTTP Client library for node.js",
   "main": "http-sync.js",
   "scripts": {


### PR DESCRIPTION
node.js async `http.request` accepts special auth option and set header if it is provided:
https://github.com/joyent/node/blob/master/lib/_http_client.js#L117

It would be good to have this option in `http-sync` as well
