### PR TITLE
update nan to ~1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "gypfile": true,
   "readmeFilename": "README.md",
   "dependencies": {
-    "nan": "~1.6.2",
+    "nan": "~1.8.0",
     "caseless": "~0.9.0"
   }
 }


### PR DESCRIPTION
`http-sync` fails to install for me on iojs 2.0.1. Updating `nan` fixes that.
