### PR TITLE
Upgrade nan to 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: node_js
 node_js:
   - 0.8
   - 0.10
-  - iojs
+  - iojs-v2
+  - iojs-v3

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "gypfile": true,
   "readmeFilename": "README.md",
   "dependencies": {
-    "nan": "~1.8.0",
+    "nan": "~2.0.8",
     "caseless": "~0.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-sync",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A synchronous HTTP Client library for node.js",
   "main": "http-sync.js",
   "scripts": {


### PR DESCRIPTION
This switches `nan` to 2.x. Mostly find/replace to switch to the namespaced function names and to append all the `.ToLocalChecked` calls. Using `nan@2.x` means that it should be compatible with both iojs 3.x and the upcoming node 4.0.0.

Tested (all on OSX):
- `nvm use 0.8 && npm i && npm test`
- `nvm use 0.10 && npm i && npm test`
- `nvm use iojs-v1 && npm i && npm test`
- `nvm use iojs-v2 && npm i && npm test`
- `nvm use iojs-v3 && npm i && npm test`

Also tested running an actual testium integration test suite on 0.10 and iojs v2 against this package and it passed. Which ran on a Linux box.
